### PR TITLE
Convert error notifications to alert on rate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,24 +110,54 @@ resource "aws_lambda_function" "lambda" {
 
 # An alarm to notify of function errors
 resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  alarm_actions       = [var.notifications_topic_arn]
+  alarm_description   = "This metric monitors the error rate on the ${var.name} lambda"
   alarm_name          = "${var.name} - High Error Rate"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "Errors"
-  namespace           = "AWS/Lambda"
-  period              = "60"
-  statistic           = "Sum"
-  threshold           = "1"
+  evaluation_periods  = "2"
+  ok_actions          = [var.notifications_topic_arn]
+  threshold           = var.error_rate_alarm_threshold
   treat_missing_data  = "notBreaching"
-  unit                = "Count"
 
-  dimensions = {
-    FunctionName = aws_lambda_function.lambda.function_name
+  metric_query {
+    id          = "error_rate"
+    expression  = "errors/invocations*100"
+    label       = "Error Rate"
+    return_data = "true"
   }
 
-  alarm_description = "This metric monitors errors on the ${var.name} lambda"
-  alarm_actions     = [var.notifications_topic_arn]
-  ok_actions        = [var.notifications_topic_arn]
+  metric_query {
+    id = "errors"
+
+    metric {
+      metric_name = "Errors"
+      namespace   = "AWS/Lambda"
+      period      = "60"
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        FunctionName = aws_lambda_function.lambda.function_name
+      }
+    }
+  }
+
+  metric_query {
+    id = "invocations"
+
+    metric {
+      metric_name = "Invocations"
+      namespace   = "AWS/Lambda"
+      period      = "60"
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        FunctionName = aws_lambda_function.lambda.function_name
+      }
+    }
+  }
+
 }
 
 # Configure logging in Cloudwatch

--- a/vars.tf
+++ b/vars.tf
@@ -4,6 +4,12 @@ variable "environment" {
   type        = map(string)
 }
 
+variable "error_rate_alarm_threshold" {
+  default     = 25
+  description = "Error rate (in percent, 1-100) at which to trigger an alarm notification"
+  type        = number
+}
+
 variable "handler" {
   description = "Name of the handler function inside the artifact (https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html)"
   type        = string


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?
Nope!

### What ticket(s) or other PRs does this relate to?
https://app.clubhouse.io/highwing/story/1470/tune-down-sensitivity-of-cloudwatch-lambda-alerts-so-they-don-t-alert-on-every-individual-failure

### What was the problem or feature?
Our current error notifications are super noisy because they alert effectively on every error occurrence.

### What was the solution?
Alert on an error percentage over time rather than an individual occurrence, and use a longer time window to evaluate.

### Where does this work fall on the Good - Fast spectrum?
Mostly fast - eventually it might be good to do some anomaly detection on this, but it seems like a good start.

### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
We'll need to update our other usages of this model (in `highwingio/airflow-dags`) to use this module, as well as the rRuby lambdas in `lambdas` to use this rather than their local version of the lambda module.
