### PR TITLE
Allow layer ARNs to be specified as an input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,7 @@ resource "aws_s3_bucket_object" "lambda_deploy_object" {
 resource "aws_lambda_function" "lambda" {
   function_name                  = var.name
   handler                        = var.handler
+  layers                         = var.layer_arns
   memory_size                    = var.memory_size
   publish                        = true
   reserved_concurrent_executions = var.reserved_concurrent_executions
@@ -87,7 +88,6 @@ resource "aws_lambda_function" "lambda" {
   s3_object_version              = aws_s3_bucket_object.lambda_deploy_object.version_id
   source_code_hash               = filebase64sha256(var.path)
   timeout                        = var.timeout
-  layers                         = var.layers
 
   dynamic "vpc_config" {
     for_each = length(var.subnet_ids) > 0 ? [1] : []

--- a/vars.tf
+++ b/vars.tf
@@ -15,10 +15,10 @@ variable "handler" {
   type        = string
 }
 
-variable "layers" {
-  description = "List of Lambda Layer ARNs to apply to the function"
-  type        = list(string)
+variable "layer_arns" {
   default     = []
+  description = "List of ARNs for layers to use with the function"
+  type        = list(string)
 }
 
 variable "log_retention_in_days" {


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?
Nope

### What ticket(s) or other PRs does this relate to?
https://app.clubhouse.io/highwing/story/1470/tune-down-sensitivity-of-cloudwatch-lambda-alerts-so-they-don-t-alert-on-every-individual-failure

### What was the problem or feature?
We need to support layers to allow our Ruby lambdas to use this module, since they specify a GPG layer after the `ruby27` move.

### What was the solution?
Expose layers configuration as a variable.

### Where does this work fall on the Good - Fast spectrum?
Both!

### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
Not specifically. Should unblock further work though.
