### PR TITLE
Bump default backup retention to 365 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ No requirements.
 | error\_rate\_alarm\_threshold | Error rate (in percent, 1-100) at which to trigger an alarm notification | `number` | `25` | no |
 | handler | Name of the handler function inside the artifact (https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html) | `string` | n/a | yes |
 | layer\_arns | List of ARNs for layers to use with the function | `list(string)` | `[]` | no |
-| log\_retention\_in\_days | Number of days to keep function logs in Cloudwatch | `number` | `7` | no |
+| log\_retention\_in\_days | Number of days to keep function logs in Cloudwatch | `number` | `365` | no |
 | memory\_size | Amount of memory (in MB) to allocate to the function | `number` | `128` | no |
 | name | Name for the function | `string` | n/a | yes |
 | notifications\_topic\_arn | SNS topic to send error notifications | `string` | n/a | yes |

--- a/vars.tf
+++ b/vars.tf
@@ -24,7 +24,7 @@ variable "layer_arns" {
 variable "log_retention_in_days" {
   description = "Number of days to keep function logs in Cloudwatch"
   type        = number
-  default     = 7
+  default     = 365
 }
 
 variable "memory_size" {


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?
Nope!

### What ticket(s) or other PRs does this relate to?
https://app.clubhouse.io/highwing/story/155/take-a-pass-to-add-encryption-retention-settings-to-all-existing-log-groups-appsync-lambdas-etc

### What was the problem or feature?
We need 1-year log retention based on SOC2 requirements

### What was the solution?
Bump the default to 365 days

### Where does this work fall on the Good - Fast spectrum?
Both

### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
We'll need to bump our dependencies on this module where it gets used.
