### PR TITLE
Lock down deploy artifact buckets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,44 @@ resource "aws_s3_bucket" "lambda_deploy" {
   }
 }
 
+# Block public access to the deploy artifacts
+resource "aws_s3_bucket_public_access_block" "lambda_deploy" {
+  bucket = aws_s3_bucket.lambda_deploy.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Deny insecure requests for deploy artifacts
+data "aws_iam_policy_document" "lambda_deploy_bucket_policy" {
+  statement {
+    sid = "OnlyAllowSSLRequests"
+
+    actions = [
+      "s3:*",
+    ]
+    effect = "Deny"
+
+    resources = [
+      aws_s3_bucket.lambda_deploy.arn,
+      "${aws_s3_bucket.lambda_deploy.arn}/*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+    principal = ["*"]
+  }
+}
+
+resource "aws_s3_bucket_policy" "lambda_deploy" {
+  bucket = aws_s3_bucket.lambda_deploy.id
+  policy = data.aws_iam_policy_document.lambda_deploy_bucket_policy.json
+}
+
 # S3 object to hold the deployed artifact
 resource "aws_s3_bucket_object" "lambda_deploy_object" {
   bucket = aws_s3_bucket.lambda_deploy.id

--- a/main.tf
+++ b/main.tf
@@ -83,18 +83,24 @@ data "aws_iam_policy_document" "lambda_deploy_bucket_policy" {
     actions = [
       "s3:*",
     ]
+
     effect = "Deny"
 
     resources = [
       aws_s3_bucket.lambda_deploy.arn,
       "${aws_s3_bucket.lambda_deploy.arn}/*",
     ]
+
     condition {
       test     = "Bool"
       variable = "aws:SecureTransport"
       values   = ["false"]
     }
-    principal = ["*"]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
   }
 }
 


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?
Nope!

### What ticket(s) or other PRs does this relate to?
Our SOC2 epic

### What was the problem or feature?
We need to lock down permissions on that deploy bucket to comply with CIS standards.

### What was the solution?
- Add a public access block
- Deny insecure requests

### Where does this work fall on the Good - Fast spectrum?
Fast!

### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
We'll need to update the usage of this module downstream to the new release.
