### PR TITLE
Add a GitHub action to keep docs in sync

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: Docs
+on:
+  - pull_request
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Generate TF Docs
+        uses: terraform-docs/gh-actions@v0.6.1
+        with:
+          working-dir: .
+          output-file: README.md
+          output-method: replace
+          git-push: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-aws-lambda-function  
+# terraform-aws-lambda-function
 Terraform module for a Lambda function with a standard configuration
 
 ## Usage
@@ -28,35 +28,55 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_metric_alarm.lambda_errors](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_iam_role_policy_attachment.lambda_basic_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_networking](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_s3_bucket.lambda_deploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_object.lambda_deploy_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_bucket_policy.lambda_deploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.lambda_deploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.lambda_deploy_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| environment | Environment variables to be passed to the function | `map(string)` | `{}` | no |
-| error\_rate\_alarm\_threshold | Error rate (in percent, 1-100) at which to trigger an alarm notification | `number` | `25` | no |
-| handler | Name of the handler function inside the artifact (https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html) | `string` | n/a | yes |
-| layer\_arns | List of ARNs for layers to use with the function | `list(string)` | `[]` | no |
-| log\_retention\_in\_days | Number of days to keep function logs in Cloudwatch | `number` | `365` | no |
-| memory\_size | Amount of memory (in MB) to allocate to the function | `number` | `128` | no |
-| name | Name for the function | `string` | n/a | yes |
-| notifications\_topic\_arn | SNS topic to send error notifications | `string` | n/a | yes |
-| path | Local path to a zipped artifact containing the function code | `string` | n/a | yes |
-| reserved\_concurrent\_executions | Reserved concurrent executions (none by default) | `number` | `null` | no |
-| role\_name | Name of the execution role for the function. It does not need to include logging/networking permissions - those policies will be added automatically. | `string` | n/a | yes |
-| runtime | Language runtime for the function (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) | `string` | n/a | yes |
-| security\_group\_ids | Security groups for the function (if run in a VPC) | `list(string)` | `[]` | no |
-| subnet\_ids | Subnets for the function (if run in a VPC) | `list(string)` | `[]` | no |
-| tags | Tags to apply to created resources | `map` | `{}` | no |
-| timeout | Function timeout in seconds | `number` | `15` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment variables to be passed to the function | `map(string)` | `{}` | no |
+| <a name="input_error_rate_alarm_threshold"></a> [error\_rate\_alarm\_threshold](#input\_error\_rate\_alarm\_threshold) | Error rate (in percent, 1-100) at which to trigger an alarm notification | `number` | `25` | no |
+| <a name="input_handler"></a> [handler](#input\_handler) | Name of the handler function inside the artifact (https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html) | `string` | n/a | yes |
+| <a name="input_layer_arns"></a> [layer\_arns](#input\_layer\_arns) | List of ARNs for layers to use with the function | `list(string)` | `[]` | no |
+| <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | Number of days to keep function logs in Cloudwatch | `number` | `365` | no |
+| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Amount of memory (in MB) to allocate to the function | `number` | `128` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name for the function | `string` | n/a | yes |
+| <a name="input_notifications_topic_arn"></a> [notifications\_topic\_arn](#input\_notifications\_topic\_arn) | SNS topic to send error notifications | `string` | n/a | yes |
+| <a name="input_path"></a> [path](#input\_path) | Local path to a zipped artifact containing the function code | `string` | n/a | yes |
+| <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | Reserved concurrent executions (none by default) | `number` | `null` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of the execution role for the function. It does not need to include logging/networking permissions - those policies will be added automatically. | `string` | n/a | yes |
+| <a name="input_runtime"></a> [runtime](#input\_runtime) | Language runtime for the function (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) | `string` | n/a | yes |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security groups for the function (if run in a VPC) | `list(string)` | `[]` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnets for the function (if run in a VPC) | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to created resources | `map(any)` | `{}` | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Function timeout in seconds | `number` | `15` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| function\_arn | ARN of the created/updated Lambda function |
-| function\_invoke\_arn | ARN for invoking the created Lambda function |
-| function\_name | Name of the created Lambda function |
-| function\_version | Version of the created/updated Lambda function |
-
+| <a name="output_function_arn"></a> [function\_arn](#output\_function\_arn) | ARN of the created/updated Lambda function |
+| <a name="output_function_invoke_arn"></a> [function\_invoke\_arn](#output\_function\_invoke\_arn) | ARN for invoking the created Lambda function |
+| <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Name of the created Lambda function |
+| <a name="output_function_version"></a> [function\_version](#output\_function\_version) | Version of the created/updated Lambda function |


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?
Nope!

### What ticket(s) or other PRs does this relate to?
Nada

### What was the problem or feature?
It's possible for docs to get out-of-sync if not manually updated.

### What was the solution?
Ensure that it happens via a Github Action

- [x] Security Impact has been considered - a third-party action can commit to the repo, but with limited scope.
- [x] Network Impacts have been considered - None

### Where does this work fall on the Good - Fast spectrum?
💨 

### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
Nope!