### PR TITLE
Save deployment artifacts to the same bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  deploy_artifact_key = "deploy.zip"
+  deploy_artifact_key = "${var.name}_deploy.zip"
   role_arn            = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"
 }
 
@@ -49,7 +49,7 @@ resource "aws_iam_role_policy_attachment" "lambda_xray" {
 # Not always required but it's more consistent for deploying larger files
 resource "aws_s3_bucket" "lambda_deploy" {
   acl           = "private"
-  bucket_prefix = "lambda-deploy"
+  bucket        = "lambda-deploy"
   force_destroy = true
 
   versioning {

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  deploy_artifact_key = "${var.name}_deploy.zip"
+  deploy_artifact_key = "${trimspace(var.name)}_deploy.zip"
   role_arn            = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"
 }
 


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?


### What ticket(s) or other PRs does this relate to?


### What was the problem or feature?
I ran into a `TooManyBuckets` error when trying to deploy: https://github.com/highwingio/airflow-dags/runs/3196432016

Currently, we create a new bucket for each lambda, and then save each lambda's deployment artifact to `deploy.zip` in its own bucket. With many lambdas, we get many buckets, and all are confusingly named like `lambda-deploy20210729203144377600000001 ` and don't indicate which lambda they're associated with.

### What was the solution?
1. Change the `deploy_artifact_key` to `<lambda name>_deploy.zip`
2. Change the deploy bucket to use `lambda_deploy` as the full name, not just the prefix

- [ ] Security Impact has been considered (if yes please describe)
- [ ] Network Impacts have been considered (if yes please describe)



### Where does this work fall on the Good - Fast spectrum?


### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
