### PR TITLE
Deploy artifacts to single bucket

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_ssm_parameter" "deployment_bucket_id" {
+  name = "/account/DEPLOYMENT_BUCKET_ID"
+}

--- a/vars.tf
+++ b/vars.tf
@@ -16,6 +16,12 @@ variable "error_rate_alarm_threshold" {
   type        = number
 }
 
+variable "git_sha" {
+  type        = string
+  description = "Git SHA hash for lambda source code"
+  default     = null
+}
+
 variable "handler" {
   description = "Name of the handler function inside the artifact (https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html)"
   type        = string


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?


### What ticket(s) or other PRs does this relate to?

https://app.shortcut.com/highwing/story/3668/reduce-number-of-deploy-buckets

### What was the problem or feature?

Lambdas artifacts are all deploying to their own poorly named buckets.

### What was the solution?

Similar to https://github.com/highwingio/lambdas/pull/2496, moves the deployment files into a single bucket. If a Git SHA isn't passed in then we can just continue to use the hash from the `deploy.zip` file to determine whether a lambda has been updated (which will generally always be the case when using the zip hash).

- [X] Security Impact has been considered (if yes please describe): Less buckets to manage security on
- [X] Network Impacts have been considered (if yes please describe): None



### Where does this work fall on the Good - Fast spectrum?


### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?

Add Git SHA to the `data-dags` lambdas and redeploy. Will also need to come back in later and clear out the old deploy files and remove the buckets.
