### PR TITLE
Tone down Cloudwatch alarms

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,58 @@ resource "aws_lambda_function" "lambda" {
   }
 }
 
+# An alarm to notify of function errors
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  alarm_actions       = [var.notifications_topic_arn]
+  alarm_description   = "This metric monitors the error rate on the ${var.name} lambda"
+  alarm_name          = "${var.name} - High Error Rate"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  threshold           = var.error_rate_alarm_threshold
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "error_rate"
+    expression  = "errors/invocations*100"
+    label       = "Error Rate"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "errors"
+
+    metric {
+      metric_name = "Errors"
+      namespace   = "AWS/Lambda"
+      period      = "600"
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        FunctionName = aws_lambda_function.lambda.function_name
+      }
+    }
+  }
+
+  metric_query {
+    id = "invocations"
+
+    metric {
+      metric_name = "Invocations"
+      namespace   = "AWS/Lambda"
+      period      = "600"
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        FunctionName = aws_lambda_function.lambda.function_name
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
 # Configure logging in Cloudwatch
 resource "aws_cloudwatch_log_group" "lambda" {
   name              = "/aws/lambda/${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -101,59 +101,6 @@ resource "aws_lambda_function" "lambda" {
   }
 }
 
-# An alarm to notify of function errors
-resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
-  alarm_actions       = [var.notifications_topic_arn]
-  alarm_description   = "This metric monitors the error rate on the ${var.name} lambda"
-  alarm_name          = "${var.name} - High Error Rate"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "2"
-  ok_actions          = [var.notifications_topic_arn]
-  threshold           = var.error_rate_alarm_threshold
-  treat_missing_data  = "notBreaching"
-
-  metric_query {
-    id          = "error_rate"
-    expression  = "errors/invocations*100"
-    label       = "Error Rate"
-    return_data = "true"
-  }
-
-  metric_query {
-    id = "errors"
-
-    metric {
-      metric_name = "Errors"
-      namespace   = "AWS/Lambda"
-      period      = "60"
-      stat        = "Sum"
-      unit        = "Count"
-
-      dimensions = {
-        FunctionName = aws_lambda_function.lambda.function_name
-      }
-    }
-  }
-
-  metric_query {
-    id = "invocations"
-
-    metric {
-      metric_name = "Invocations"
-      namespace   = "AWS/Lambda"
-      period      = "60"
-      stat        = "Sum"
-      unit        = "Count"
-
-      dimensions = {
-        FunctionName = aws_lambda_function.lambda.function_name
-      }
-    }
-  }
-
-  tags = var.tags
-}
-
 # Configure logging in Cloudwatch
 resource "aws_cloudwatch_log_group" "lambda" {
   name              = "/aws/lambda/${var.name}"


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?


### What ticket(s) or other PRs does this relate to?

https://app.shortcut.com/highwing/story/1470/tune-down-sensitivity-of-cloudwatch-lambda-alerts-so-they-don-t-alert-on-every-individual-failure

### What was the problem or feature?

I propose just completely removing these default alarms and focusing on alerts that are more narrowly defined and valuable.

### What was the solution?

- [X] Security Impact has been considered (if yes please describe)
- [X] Network Impacts have been considered (if yes please describe)



### Where does this work fall on the Good - Fast spectrum?


### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?

Will need to release a new version and update the lambdas using this module in `data-dags` and `lambdas` repos.
