### PR TITLE
Add option to specify lambda via image_uri

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.3.0
       - id: Init
         run: terraform init -no-color
       - id: Fmt

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,26 @@ locals {
   deployment_bucket_id = coalesce(var.deployment_bucket_id, data.aws_ssm_parameter.deployment_bucket_id.value)
   source_hash          = coalesce(var.git_sha, filebase64sha256(var.path))
   role_arn             = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"
+  validation {
+    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+    error_message = "Cannot specify image_uri AND path"
+  }
+  validation {
+    condition = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
+    error_message = "Cannot specify image_uri AND handler"
+  }
+  validation {
+    condition = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
+    error_message = "Cannot specify image_uri AND layer_arns"
+  }
+  validation {
+    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+    error_message = "Cannot specify image_uri AND path"
+  }
+  validation {
+    condition = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
+    error_message = "Cannot specify image_uri AND runtime"
+  }
 }
 
 # Configure default role permissions

--- a/main.tf
+++ b/main.tf
@@ -102,26 +102,41 @@ resource "aws_lambda_function" "lambda" {
     mode = "Active"
   }
 
-  precondition {
-    condition     = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
-    error_message = "Cannot specify image_uri AND path"
+  lifecycle {
+    precondition {
+      condition     = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+      error_message = "Cannot specify image_uri AND path"
+    }
   }
-  precondition {
-    condition     = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
-    error_message = "Cannot specify image_uri AND handler"
+
+  lifecycle {
+    precondition {
+      condition     = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
+      error_message = "Cannot specify image_uri AND handler"
+    }
   }
-  precondition {
-    condition     = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
-    error_message = "Cannot specify image_uri AND layer_arns"
+
+  lifecycle {
+    precondition {
+      condition     = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
+      error_message = "Cannot specify image_uri AND layer_arns"
+    }
   }
-  precondition {
-    condition     = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
-    error_message = "Cannot specify image_uri AND path"
+
+  lifecycle {
+    precondition {
+      condition     = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+      error_message = "Cannot specify image_uri AND path"
+    }
   }
-  precondition {
-    condition     = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
-    error_message = "Cannot specify image_uri AND runtime"
+
+  lifecycle {
+    precondition {
+      condition     = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
+      error_message = "Cannot specify image_uri AND runtime"
+    }
   }
+
 }
 
 # An alarm to notify of function errors

--- a/main.tf
+++ b/main.tf
@@ -101,27 +101,6 @@ resource "aws_lambda_function" "lambda" {
   tracing_config {
     mode = "Active"
   }
-
-  precondition {
-    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
-    error_message = "Cannot specify image_uri AND path"
-  }
-  precondition {
-    condition = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
-    error_message = "Cannot specify image_uri AND handler"
-  }
-  precondition {
-    condition = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
-    error_message = "Cannot specify image_uri AND layer_arns"
-  }
-  precondition {
-    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
-    error_message = "Cannot specify image_uri AND path"
-  }
-  precondition {
-    condition = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
-    error_message = "Cannot specify image_uri AND runtime"
-  }
 }
 
 # An alarm to notify of function errors

--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,27 @@ resource "aws_lambda_function" "lambda" {
   tracing_config {
     mode = "Active"
   }
+
+  precondition {
+    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+    error_message = "Cannot specify image_uri AND path"
+  }
+  precondition {
+    condition = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
+    error_message = "Cannot specify image_uri AND handler"
+  }
+  precondition {
+    condition = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
+    error_message = "Cannot specify image_uri AND layer_arns"
+  }
+  precondition {
+    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+    error_message = "Cannot specify image_uri AND path"
+  }
+  precondition {
+    condition = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
+    error_message = "Cannot specify image_uri AND runtime"
+  }
 }
 
 # An alarm to notify of function errors

--- a/main.tf
+++ b/main.tf
@@ -103,23 +103,23 @@ resource "aws_lambda_function" "lambda" {
   }
 
   precondition {
-    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+    condition     = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
     error_message = "Cannot specify image_uri AND path"
   }
   precondition {
-    condition = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
+    condition     = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
     error_message = "Cannot specify image_uri AND handler"
   }
   precondition {
-    condition = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
+    condition     = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
     error_message = "Cannot specify image_uri AND layer_arns"
   }
   precondition {
-    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+    condition     = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
     error_message = "Cannot specify image_uri AND path"
   }
   precondition {
-    condition = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
+    condition     = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
     error_message = "Cannot specify image_uri AND runtime"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,7 @@ resource "aws_iam_role_policy_attachment" "lambda_insights" {
 
 # S3 object to hold the deployed artifact
 resource "aws_s3_bucket_object" "lambda_deploy_object" {
+  for_each = var.image_uri == null ? [1] : []
   bucket      = local.deployment_bucket_id
   key         = "${var.name}/${local.deploy_artifact_key}"
   source      = var.path
@@ -66,18 +67,19 @@ resource "aws_lambda_function" "lambda" {
   function_name = var.name
   description   = var.description
   handler       = var.handler
-  layers = concat(
+  layers = var.image_uri == null ? concat(
     var.layer_arns,
     ["arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:14"] # ARN for us-east-1
-  )
+  ) : null
   memory_size                    = var.memory_size
   publish                        = true
   reserved_concurrent_executions = var.reserved_concurrent_executions
   role                           = local.role_arn
   runtime                        = var.runtime
-  s3_bucket                      = local.deployment_bucket_id
-  s3_key                         = aws_s3_bucket_object.lambda_deploy_object.key
-  s3_object_version              = aws_s3_bucket_object.lambda_deploy_object.version_id
+  s3_bucket                      = var.image_uri == null ? local.deployment_bucket_id : null
+  s3_key                         = var.image_uri == null ? aws_s3_bucket_object.lambda_deploy_object.key : null
+  s3_object_version              = var.image_uri == null ? aws_s3_bucket_object.lambda_deploy_object.version_id : null
+  image_uri = var.image_uri
   tags                           = var.tags
   timeout                        = var.timeout
 

--- a/main.tf
+++ b/main.tf
@@ -27,26 +27,6 @@ locals {
   deployment_bucket_id = coalesce(var.deployment_bucket_id, data.aws_ssm_parameter.deployment_bucket_id.value)
   source_hash          = coalesce(var.git_sha, filebase64sha256(var.path))
   role_arn             = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"
-  validation {
-    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
-    error_message = "Cannot specify image_uri AND path"
-  }
-  validation {
-    condition = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
-    error_message = "Cannot specify image_uri AND handler"
-  }
-  validation {
-    condition = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
-    error_message = "Cannot specify image_uri AND layer_arns"
-  }
-  validation {
-    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
-    error_message = "Cannot specify image_uri AND path"
-  }
-  validation {
-    condition = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
-    error_message = "Cannot specify image_uri AND runtime"
-  }
 }
 
 # Configure default role permissions
@@ -120,6 +100,27 @@ resource "aws_lambda_function" "lambda" {
 
   tracing_config {
     mode = "Active"
+  }
+
+  precondition {
+    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+    error_message = "Cannot specify image_uri AND path"
+  }
+  precondition {
+    condition = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
+    error_message = "Cannot specify image_uri AND handler"
+  }
+  precondition {
+    condition = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
+    error_message = "Cannot specify image_uri AND layer_arns"
+  }
+  precondition {
+    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+    error_message = "Cannot specify image_uri AND path"
+  }
+  precondition {
+    condition = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
+    error_message = "Cannot specify image_uri AND runtime"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -77,8 +77,8 @@ resource "aws_lambda_function" "lambda" {
   role                           = local.role_arn
   runtime                        = var.runtime
   s3_bucket                      = var.image_uri == null ? local.deployment_bucket_id : null
-  s3_key                         = var.image_uri == null ? aws_s3_bucket_object.lambda_deploy_object.key : null
-  s3_object_version              = var.image_uri == null ? aws_s3_bucket_object.lambda_deploy_object.version_id : null
+  s3_key                         = var.image_uri == null ? aws_s3_bucket_object.lambda_deploy_object[0].key : null
+  s3_object_version              = var.image_uri == null ? aws_s3_bucket_object.lambda_deploy_object[0].version_id : null
   image_uri                      = var.image_uri
   tags                           = var.tags
   timeout                        = var.timeout

--- a/main.tf
+++ b/main.tf
@@ -107,30 +107,18 @@ resource "aws_lambda_function" "lambda" {
       condition     = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
       error_message = "Cannot specify image_uri AND path"
     }
-  }
-
-  lifecycle {
     precondition {
       condition     = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
       error_message = "Cannot specify image_uri AND handler"
     }
-  }
-
-  lifecycle {
     precondition {
       condition     = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
       error_message = "Cannot specify image_uri AND layer_arns"
     }
-  }
-
-  lifecycle {
     precondition {
       condition     = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
       error_message = "Cannot specify image_uri AND path"
     }
-  }
-
-  lifecycle {
     precondition {
       condition     = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
       error_message = "Cannot specify image_uri AND runtime"

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "lambda_insights" {
 
 # S3 object to hold the deployed artifact
 resource "aws_s3_bucket_object" "lambda_deploy_object" {
-  for_each = var.image_uri == null ? [1] : []
+  for_each    = var.image_uri == null ? [1] : []
   bucket      = local.deployment_bucket_id
   key         = "${var.name}/${local.deploy_artifact_key}"
   source      = var.path
@@ -79,7 +79,7 @@ resource "aws_lambda_function" "lambda" {
   s3_bucket                      = var.image_uri == null ? local.deployment_bucket_id : null
   s3_key                         = var.image_uri == null ? aws_s3_bucket_object.lambda_deploy_object.key : null
   s3_object_version              = var.image_uri == null ? aws_s3_bucket_object.lambda_deploy_object.version_id : null
-  image_uri = var.image_uri
+  image_uri                      = var.image_uri
   tags                           = var.tags
   timeout                        = var.timeout
 

--- a/vars.tf
+++ b/vars.tf
@@ -5,9 +5,9 @@ variable "description" {
 }
 
 variable "image_uri" {
-  default = null
+  default     = null
   description = "Image URI of the ECR container image for the Lambda Function. Overrides the use of path variable & s3 deployment object"
-  type = string
+  type        = string
 }
 
 variable "deployment_bucket_id" {
@@ -35,7 +35,7 @@ variable "git_sha" {
 }
 
 variable "handler" {
-  default = null
+  default     = null
   description = "Name of the handler function inside the artifact (https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html)"
   type        = string
 }
@@ -69,7 +69,7 @@ variable "notifications_topic_arn" {
 }
 
 variable "path" {
-  default = null
+  default     = null
   description = "Local path to a zipped artifact containing the function code"
   type        = string
 }
@@ -86,7 +86,7 @@ variable "role_name" {
 }
 
 variable "runtime" {
-  default = null
+  default     = null
   type        = string
   description = "Language runtime for the function (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)"
 }

--- a/vars.tf
+++ b/vars.tf
@@ -4,6 +4,16 @@ variable "description" {
   type        = string
 }
 
+variable "image_uri" {
+  default = null
+  description = "Image URI of the ECR container image for the Lambda Function. Overrides the use of path variable & s3 deployment object"
+  type = string
+
+  validation {
+    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+  }
+}
+
 variable "deployment_bucket_id" {
   default     = null
   description = "ID of S3 bucket that should store our deployment artifacts. Will use the /account/DEPLOYMENT_BUCKET_ID value from SSM unless specified otherwise."
@@ -29,14 +39,23 @@ variable "git_sha" {
 }
 
 variable "handler" {
+  default = null
   description = "Name of the handler function inside the artifact (https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html)"
   type        = string
+
+  validation {
+    condition = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
+  }
 }
 
 variable "layer_arns" {
   default     = []
   description = "List of ARNs for layers to use with the function"
   type        = list(string)
+
+  validation {
+    condition = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
+  }
 }
 
 variable "log_retention_in_days" {
@@ -62,8 +81,13 @@ variable "notifications_topic_arn" {
 }
 
 variable "path" {
+  default = null
   description = "Local path to a zipped artifact containing the function code"
   type        = string
+
+  validation {
+    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
+  }
 }
 
 variable "reserved_concurrent_executions" {
@@ -78,8 +102,13 @@ variable "role_name" {
 }
 
 variable "runtime" {
+  default = null
   type        = string
   description = "Language runtime for the function (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)"
+
+  validation {
+    condition = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
+  }
 }
 
 variable "security_group_ids" {

--- a/vars.tf
+++ b/vars.tf
@@ -8,10 +8,6 @@ variable "image_uri" {
   default = null
   description = "Image URI of the ECR container image for the Lambda Function. Overrides the use of path variable & s3 deployment object"
   type = string
-
-  validation {
-    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
-  }
 }
 
 variable "deployment_bucket_id" {
@@ -42,20 +38,12 @@ variable "handler" {
   default = null
   description = "Name of the handler function inside the artifact (https://docs.aws.amazon.com/lambda/latest/dg/configuration-console.html)"
   type        = string
-
-  validation {
-    condition = (var.image_uri != null && var.handler == null) || (var.image_uri == null && var.handler != null)
-  }
 }
 
 variable "layer_arns" {
   default     = []
   description = "List of ARNs for layers to use with the function"
   type        = list(string)
-
-  validation {
-    condition = (var.image_uri != null && length(var.layer_arns) == 0) || (var.image_uri == null)
-  }
 }
 
 variable "log_retention_in_days" {
@@ -84,10 +72,6 @@ variable "path" {
   default = null
   description = "Local path to a zipped artifact containing the function code"
   type        = string
-
-  validation {
-    condition = (var.image_uri != null && var.path == null) || (var.image_uri == null && var.path != null)
-  }
 }
 
 variable "reserved_concurrent_executions" {
@@ -105,10 +89,6 @@ variable "runtime" {
   default = null
   type        = string
   description = "Language runtime for the function (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)"
-
-  validation {
-    condition = (var.image_uri != null && var.runtime == null) || (var.image_uri == null && var.path != null)
-  }
 }
 
 variable "security_group_ids" {


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?


### What ticket(s) or other PRs does this relate to?


### What was the problem or feature?
Want to be able to create a Lambda based on an image in ECR.

### What was the solution?
Add the `image_uri` option to the variables and to the creation of the Lambda resource. ~Additionally add verifications and conditionals to ensure that we don't specify conflicting S3 and ECR configurations.~ ([this commit](https://github.com/highwingio/terraform-aws-lambda-function/pull/15/commits/2650eaa1166a5576e2b2792a3888633b677f773b), we can add these once we get to Terraform > 1.2.0)

- [x] Security Impact has been considered (if yes please describe): none
- [x] Network Impacts have been considered (if yes please describe): none



### Where does this work fall on the Good - Fast spectrum?


### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
