### PR TITLE
specify maps instead of lists in for_each condition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "lambda_insights" {
 
 # S3 object to hold the deployed artifact
 resource "aws_s3_bucket_object" "lambda_deploy_object" {
-  for_each    = var.image_uri == null ? {1 = 1} : {}
+  count    = var.image_uri == null ? 1 : 0
   bucket      = local.deployment_bucket_id
   key         = "${var.name}/${local.deploy_artifact_key}"
   source      = var.path

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "lambda_insights" {
 
 # S3 object to hold the deployed artifact
 resource "aws_s3_bucket_object" "lambda_deploy_object" {
-  for_each    = var.image_uri == null ? [1] : []
+  for_each    = var.image_uri == null ? {1 = 1} : {}
   bucket      = local.deployment_bucket_id
   key         = "${var.name}/${local.deploy_artifact_key}"
   source      = var.path

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "lambda_insights" {
 
 # S3 object to hold the deployed artifact
 resource "aws_s3_bucket_object" "lambda_deploy_object" {
-  for_each    = var.image_uri == null ? { 1 = 1 } : {}
+  count       = var.image_uri == null ? 1 : 0
   bucket      = local.deployment_bucket_id
   key         = "${var.name}/${local.deploy_artifact_key}"
   source      = var.path

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "lambda_insights" {
 
 # S3 object to hold the deployed artifact
 resource "aws_s3_bucket_object" "lambda_deploy_object" {
-  for_each    = var.image_uri == null ? {1 = 1} : {}
+  for_each    = var.image_uri == null ? { 1 = 1 } : {}
   bucket      = local.deployment_bucket_id
   key         = "${var.name}/${local.deploy_artifact_key}"
   source      = var.path

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@
 locals {
   deploy_artifact_key  = "deploy.zip"
   deployment_bucket_id = coalesce(var.deployment_bucket_id, data.aws_ssm_parameter.deployment_bucket_id.value)
-  source_hash          = coalesce(var.git_sha, filebase64sha256(var.path))
+  source_hash          = coalesce(var.git_sha, try(filebase64sha256(var.path), null))
   role_arn             = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"
 }
 


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?


### What ticket(s) or other PRs does this relate to?


### What was the problem or feature?
Running into some issues when using v1.1.8 of this module:
https://github.com/highwingio/data-dags/actions/runs/3101006002/jobs/5021978070
1. `or_each    = var.image_uri == null ? [1] : []` is failing because 'the "for_each" argument
│ must be a map, or set of strings, and you have provided a value of type
│ list of number.'
2. `source_hash          = coalesce(var.git_sha, filebase64sha256(var.path))` is failing because '"path" parameter: argument must not be null'

### What was the solution?
1. Switch from specifying lists (`[1]`) to maps (`{1 = 1}`)
2. Add a `try`

- [x] Security Impact has been considered (if yes please describe): none
- [x] Network Impacts have been considered (if yes please describe): none



### Where does this work fall on the Good - Fast spectrum?


### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
