### PR TITLE
Bump log retention to 3 years

### DIFF
--- a/vars.tf
+++ b/vars.tf
@@ -49,7 +49,7 @@ variable "layer_arns" {
 variable "log_retention_in_days" {
   description = "Number of days to keep function logs in Cloudwatch"
   type        = number
-  default     = 365
+  default     = 365 * 3
 }
 
 variable "memory_size" {

--- a/vars.tf
+++ b/vars.tf
@@ -49,7 +49,7 @@ variable "layer_arns" {
 variable "log_retention_in_days" {
   description = "Number of days to keep function logs in Cloudwatch"
   type        = number
-  default     = 365 * 3
+  default     = 1096
 }
 
 variable "memory_size" {


### PR DESCRIPTION
### Are there any dependencies (software or human) that need to be addressed before this PR is merged?
Nope

### What ticket(s) or other PRs does this relate to?
https://3.basecamp.com/5006882/buckets/31580731/card_tables/cards/6085578964

### What was the problem or feature?
Customers asking for longer log retention

### What was the solution?
Bump the default from 1 to 3 years.

- [x] Security Impact has been considered: None
- [x] Network Impacts have been considered: None

### Where does this work fall on the Good - Fast spectrum?
💨 

### Any additional work needed as a result of merging this PR (deploy steps, other PRs, etc.)?
We'll need to release and bump the version of this module in downstream consumers.